### PR TITLE
Update proposal for build.sh

### DIFF
--- a/packages/build.sh
+++ b/packages/build.sh
@@ -145,7 +145,7 @@ function get_untar_patch() {
 	# get source file and unpack it
 	cd $PKGDIR
 	if [ ! -f $SRCFILE ]; then
-		wget --no-check-certificate $URL || exit 1
+		wget --no-check-certificate $URL -O $SRCFILE || exit 1
 	fi
 	if [ ! -d $SRCDIR ]; then
 		echo Extracting sources


### PR DESCRIPTION
I noticed that sometimes files are named literally when downloaded... like, e.g.:

<packagename>.tar.gz?raw=true

so then fails when trying to uncompress automatically.

I think this fix this problem, Merge if you confirm this doesn't affect compilation on your side.